### PR TITLE
fixes #88: simplified file url handling in Downloader_iOS_Handler

### DIFF
--- a/iOS/G3MiOSSDK/Specific/Derived/Downloader_iOS_Handler.mm
+++ b/iOS/G3MiOSSDK/Specific/Derived/Downloader_iOS_Handler.mm
@@ -178,20 +178,7 @@
     __block NSError *error = nil;
 
     if (_url->isFileProtocol()) {
-      const IStringUtils* su = IStringUtils::instance();
-
-      const std::string fileFullName = IStringUtils::instance()->replaceSubstring(_url->_path,
-                                                                                  URL::FILE_PROTOCOL,
-                                                                                  "");
-      const int dotPos = su->indexOf(fileFullName, ".");
-
-      NSString* fileName = [ NSString stringWithCppString: su->left(fileFullName, dotPos) ];
-
-      NSString* fileExt = [ NSString stringWithCppString: su->substring(fileFullName, dotPos + 1, fileFullName.size()) ];
-
-      NSString* filePath = [[NSBundle mainBundle] pathForResource: fileName
-                                                           ofType: fileExt];
-      data = [NSData dataWithContentsOfFile:filePath];
+      data = [NSData dataWithContentsOfURL:_nsURL];
       statusCode = (data) ? 200 : 404;
     }
     else {


### PR DESCRIPTION
This change allows loading of pointcloud files from the app's Documents directory, rather than assuming the pointcloud file is a bundle resource.
