### PR TITLE
unicode character issue

### DIFF
--- a/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/Vector2D.java
+++ b/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/Vector2D.java
@@ -156,7 +156,7 @@ public class Vector2D
   public static Vector2D intersectionOfTwoLines(Vector2D p1, Vector2D r1, Vector2D p2, Vector2D r2)
   {
   
-    //u = (p2 − p1) × r1 / (r1 × r2)
+    //u = (p2 - p1) × r1 / (r1 × r2)
     //out = p2 + u x r2
   
     double u = ((p2.sub(p1)).dot(r1)) / r1.dot(r2);

--- a/iOS/G3MiOSSDK/Commons/Geometry/Vector2D.cpp
+++ b/iOS/G3MiOSSDK/Commons/Geometry/Vector2D.cpp
@@ -32,7 +32,7 @@ const std::string Vector2D::description() const {
 Vector2D Vector2D::intersectionOfTwoLines(const Vector2D& p1, const Vector2D& r1,
                                           const Vector2D& p2, const Vector2D& r2) {
   
-  //u = (p2 − p1) × r1 / (r1 × r2)
+  //u = (p2 - p1) × r1 / (r1 × r2)
   //out = p2 + u x r2
   
   double u = ((p2.sub(p1)).dot(r1)) / r1.dot(r2);


### PR DESCRIPTION
Apparently one of the minus characters in the Vector2D comments is a unicode character. (hex E28892)
This character caused issues with android studio on windows. 
We propose to change it to the plain ASCII minus character. (hex 2D)

( We are trying to break up the gigantic #153 pull request into semantically atomic issues to make it easier to process. This pull request is the first such a breakout. )
