### PR TITLE
isPremultiplied api15 fix

### DIFF
--- a/Android/G3MAndroidSDK/src/org/glob3/mobile/specific/Image_Android.java
+++ b/Android/G3MAndroidSDK/src/org/glob3/mobile/specific/Image_Android.java
@@ -165,7 +165,11 @@ public final class Image_Android
 
    @Override
    public boolean isPremultiplied() {
-      return (_bitmapHolder._bitmap == null) ? false : _bitmapHolder._bitmap.isPremultiplied();
+      if(_bitmapHolder._bitmap == null) {
+         return false;
+      }
+      Bitmap bmp = _bitmapHolder._bitmap;
+      return bmp.getConfig() != Bitmap.Config.RGB_565 && bmp.hasAlpha();
    }
 
 


### PR DESCRIPTION
isPremultiplied has only been available since android api level 17. If we replace it with this implementation g3m can work on api level 15 too.
