### PR TITLE
Chrome camera issue fix

### DIFF
--- a/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/BusyMeshRenderer.java
+++ b/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/BusyMeshRenderer.java
@@ -153,7 +153,7 @@ public class BusyMeshRenderer implements ProtoRenderer, EffectTarget
     GL gl = rc.getGL();
     createGLState();
   
-    gl.clearScreen(_backgroundColor);
+    //gl->clearScreen(*_backgroundColor);
   
     Mesh mesh = getMesh(rc);
     if (mesh != null)

--- a/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/Camera.java
+++ b/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/Camera.java
@@ -95,8 +95,8 @@ public class Camera
     {
       _timestamp++;
   
-      final int viewPortH = (_viewPortHeight == 0)?height:_viewPortHeight;
-      final int viewPortW = (_viewPortWidth == 0)?width:_viewPortWidth;
+      final int viewPortH = (_viewPortHeight == 0) ? height : _viewPortHeight;
+      final int viewPortW = (_viewPortWidth == 0) ? width : _viewPortWidth;
       _tanHalfVerticalFOV = _tanHalfVerticalFOV / width * viewPortW;
       _tanHalfHorizontalFOV = _tanHalfHorizontalFOV / height * viewPortH;
   

--- a/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/Camera.java
+++ b/Commons/G3MSharedSDK/src/org/glob3/mobile/generated/Camera.java
@@ -95,8 +95,10 @@ public class Camera
     {
       _timestamp++;
   
-      _tanHalfVerticalFOV = _tanHalfVerticalFOV / width * _viewPortWidth;
-      _tanHalfHorizontalFOV = _tanHalfHorizontalFOV / height * _viewPortHeight;
+      final int viewPortH = (_viewPortHeight == 0)?height:_viewPortHeight;
+      final int viewPortW = (_viewPortWidth == 0)?width:_viewPortWidth;
+      _tanHalfVerticalFOV = _tanHalfVerticalFOV / width * viewPortW;
+      _tanHalfHorizontalFOV = _tanHalfHorizontalFOV / height * viewPortH;
   
       _viewPortWidth = width;
       _viewPortHeight = height;
@@ -792,45 +794,6 @@ public class Camera
     return _frustum;
   }
 
-  //FrustumData calculateFrustumData() const {
-  //  const double height = getGeodeticPosition()._height;
-  //  double zNear = height * 0.1;
-  //
-  //  double zFar = _planet->distanceToHorizon(_position.asVector3D());
-  //
-  //  const double goalRatio = 1000;
-  //  const double ratio = zFar / zNear;
-  //  if (ratio < goalRatio) {
-  //    zNear = zFar / goalRatio;
-  //  }
-  //
-  //  if (ISNAN(_tanHalfHorizontalFOV) || ISNAN(_tanHalfVerticalFOV)) {
-  //    const double ratioScreen = (double) _viewPortHeight / _viewPortWidth;
-  //
-  //    if (ISNAN(_tanHalfHorizontalFOV) && ISNAN(_tanHalfVerticalFOV)) {
-  //      //Default behaviour _tanHalfFieldOfView = 0.3  =>  aprox tan(34 degrees / 2)
-  //      _tanHalfVerticalFOV   = 0.3;
-  //      _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
-  //    }
-  //    else {
-  //      if (ISNAN(_tanHalfHorizontalFOV)) {
-  //        _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
-  //      }
-  //      else if ISNAN(_tanHalfVerticalFOV) {
-  //        _tanHalfVerticalFOV = _tanHalfHorizontalFOV * ratioScreen;
-  //      }
-  //    }
-  //  }
-  //
-  //  const double right  = _tanHalfHorizontalFOV * zNear;
-  //  const double left   = -right;
-  //  const double top    = _tanHalfVerticalFOV * zNear;
-  //  const double bottom = -top;
-  //  return FrustumData(left,   right,
-  //                     bottom, top,
-  //                     zNear,  zFar);
-  //}
-  
   private FrustumData calculateFrustumData()
   {
     final double height = getGeodeticPosition()._height;
@@ -845,50 +808,34 @@ public class Camera
       zNear = zFar / goalRatio;
     }
   
-    //  int __TODO_remove_debug_code;
-    //  printf(">>> height=%f zNear=%f zFar=%f ratio=%f\n",
-    //         height,
-    //         zNear,
-    //         zFar,
-    //         ratio);
-  
-    // compute rest of frustum numbers
-  
-    double tanHalfHFOV = _tanHalfHorizontalFOV;
-    double tanHalfVFOV = _tanHalfVerticalFOV;
-  
-    if ((tanHalfHFOV != tanHalfHFOV) || (tanHalfVFOV != tanHalfVFOV))
+    if ((_tanHalfHorizontalFOV != _tanHalfHorizontalFOV) || (_tanHalfVerticalFOV != _tanHalfVerticalFOV))
     {
       final double ratioScreen = (double) _viewPortHeight / _viewPortWidth;
   
-      if ((tanHalfHFOV != tanHalfHFOV) && (tanHalfVFOV != tanHalfVFOV))
+      if ((_tanHalfHorizontalFOV != _tanHalfHorizontalFOV) && (_tanHalfVerticalFOV != _tanHalfVerticalFOV))
       {
-        tanHalfVFOV = 0.3; //Default behaviour _tanHalfFieldOfView = 0.3 => aprox tan(34 degrees / 2)
-        tanHalfHFOV = tanHalfVFOV / ratioScreen;
+        //Default behaviour _tanHalfFieldOfView = 0.3  =>  aprox tan(34 degrees / 2)
+        _tanHalfVerticalFOV = 0.3;
+        _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
       }
       else
       {
-        if ((tanHalfHFOV != tanHalfHFOV))
+        if ((_tanHalfHorizontalFOV != _tanHalfHorizontalFOV))
         {
-          tanHalfHFOV = tanHalfVFOV / ratioScreen;
+          _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
         }
-        else
+        else if (_tanHalfVerticalFOV != _tanHalfVerticalFOV)
         {
-          if (tanHalfVFOV != tanHalfVFOV)
-          {
-            tanHalfVFOV = tanHalfHFOV * ratioScreen;
-          }
+          _tanHalfVerticalFOV = _tanHalfHorizontalFOV * ratioScreen;
         }
       }
     }
   
-    final double right = tanHalfHFOV * zNear;
+    final double right = _tanHalfHorizontalFOV * zNear;
     final double left = -right;
-    final double top = tanHalfVFOV * zNear;
+    final double top = _tanHalfVerticalFOV * zNear;
     final double bottom = -top;
-  
     return new FrustumData(left, right, bottom, top, zNear, zFar);
-  
   }
 
   // opengl projection matrix

--- a/iOS/G3MiOSSDK/Commons/Cameras/Camera.cpp
+++ b/iOS/G3MiOSSDK/Commons/Cameras/Camera.cpp
@@ -135,8 +135,8 @@ void Camera::resizeViewport(int width, int height) {
       (height != _viewPortHeight)) {
     _timestamp++;
       
-    const int viewPortH = (_viewPortHeight == 0)?height:_viewPortHeight;
-    const int viewPortW = (_viewPortWidth == 0)?width:_viewPortWidth;
+    const int viewPortH = (_viewPortHeight == 0) ? height : _viewPortHeight;
+    const int viewPortW = (_viewPortWidth  == 0) ? width  : _viewPortWidth;
     _tanHalfVerticalFOV   = _tanHalfVerticalFOV   / width  * viewPortW;
     _tanHalfHorizontalFOV = _tanHalfHorizontalFOV / height * viewPortH;
 

--- a/iOS/G3MiOSSDK/Commons/Cameras/Camera.cpp
+++ b/iOS/G3MiOSSDK/Commons/Cameras/Camera.cpp
@@ -134,9 +134,11 @@ void Camera::resizeViewport(int width, int height) {
   if ((width  != _viewPortWidth) ||
       (height != _viewPortHeight)) {
     _timestamp++;
-
-    _tanHalfVerticalFOV   = _tanHalfVerticalFOV   / width  * _viewPortWidth;
-    _tanHalfHorizontalFOV = _tanHalfHorizontalFOV / height * _viewPortHeight;
+      
+    const int viewPortH = (_viewPortHeight == 0)?height:_viewPortHeight;
+    const int viewPortW = (_viewPortWidth == 0)?width:_viewPortWidth;
+    _tanHalfVerticalFOV   = _tanHalfVerticalFOV   / width  * viewPortW;
+    _tanHalfHorizontalFOV = _tanHalfHorizontalFOV / height * viewPortH;
 
     _viewPortWidth  = width;
     _viewPortHeight = height;
@@ -372,45 +374,6 @@ void Camera::setPointOfView(const Geodetic3D& center,
   //  _dirtyFlags.setAllDirty();
 }
 
-//FrustumData Camera::calculateFrustumData() const {
-//  const double height = getGeodeticPosition()._height;
-//  double zNear = height * 0.1;
-//
-//  double zFar = _planet->distanceToHorizon(_position.asVector3D());
-//
-//  const double goalRatio = 1000;
-//  const double ratio = zFar / zNear;
-//  if (ratio < goalRatio) {
-//    zNear = zFar / goalRatio;
-//  }
-//
-//  if (ISNAN(_tanHalfHorizontalFOV) || ISNAN(_tanHalfVerticalFOV)) {
-//    const double ratioScreen = (double) _viewPortHeight / _viewPortWidth;
-//
-//    if (ISNAN(_tanHalfHorizontalFOV) && ISNAN(_tanHalfVerticalFOV)) {
-//      //Default behaviour _tanHalfFieldOfView = 0.3  =>  aprox tan(34 degrees / 2)
-//      _tanHalfVerticalFOV   = 0.3;
-//      _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
-//    }
-//    else {
-//      if (ISNAN(_tanHalfHorizontalFOV)) {
-//        _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
-//      }
-//      else if ISNAN(_tanHalfVerticalFOV) {
-//        _tanHalfVerticalFOV = _tanHalfHorizontalFOV * ratioScreen;
-//      }
-//    }
-//  }
-//
-//  const double right  = _tanHalfHorizontalFOV * zNear;
-//  const double left   = -right;
-//  const double top    = _tanHalfVerticalFOV * zNear;
-//  const double bottom = -top;
-//  return FrustumData(left,   right,
-//                     bottom, top,
-//                     zNear,  zFar);
-//}
-
 FrustumData Camera::calculateFrustumData() const {
   const double height = getGeodeticPosition()._height;
   double zNear = height * 0.1;
@@ -423,47 +386,34 @@ FrustumData Camera::calculateFrustumData() const {
     zNear = zFar / goalRatio;
   }
 
-  //  int __TODO_remove_debug_code;
-  //  printf(">>> height=%f zNear=%f zFar=%f ratio=%f\n",
-  //         height,
-  //         zNear,
-  //         zFar,
-  //         ratio);
-
-  // compute rest of frustum numbers
-
-  double tanHalfHFOV = _tanHalfHorizontalFOV;
-  double tanHalfVFOV = _tanHalfVerticalFOV;
-
-  if (ISNAN(tanHalfHFOV) || ISNAN(tanHalfVFOV)) {
+  if (ISNAN(_tanHalfHorizontalFOV) || ISNAN(_tanHalfVerticalFOV)) {
     const double ratioScreen = (double) _viewPortHeight / _viewPortWidth;
 
-    if (ISNAN(tanHalfHFOV) && ISNAN(tanHalfVFOV)) {
-      tanHalfVFOV = 0.3; //Default behaviour _tanHalfFieldOfView = 0.3  =>  aprox tan(34 degrees / 2)
-      tanHalfHFOV = tanHalfVFOV / ratioScreen;
+    if (ISNAN(_tanHalfHorizontalFOV) && ISNAN(_tanHalfVerticalFOV)) {
+      //Default behaviour _tanHalfFieldOfView = 0.3  =>  aprox tan(34 degrees / 2)
+      _tanHalfVerticalFOV   = 0.3;
+      _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
     }
     else {
-      if (ISNAN(tanHalfHFOV)) {
-        tanHalfHFOV = tanHalfVFOV / ratioScreen;
+      if (ISNAN(_tanHalfHorizontalFOV)) {
+        _tanHalfHorizontalFOV = _tanHalfVerticalFOV / ratioScreen;
       }
-      else {
-        if ISNAN(tanHalfVFOV) {
-          tanHalfVFOV = tanHalfHFOV * ratioScreen;
-        }
+      else if ISNAN(_tanHalfVerticalFOV) {
+        _tanHalfVerticalFOV = _tanHalfHorizontalFOV * ratioScreen;
       }
     }
   }
 
-  const double right = tanHalfHFOV * zNear;
-  const double left = -right;
-  const double top = tanHalfVFOV * zNear;
+  const double right  = _tanHalfHorizontalFOV * zNear;
+  const double left   = -right;
+  const double top    = _tanHalfVerticalFOV * zNear;
   const double bottom = -top;
-
-  return FrustumData(left, right,
+  return FrustumData(left,   right,
                      bottom, top,
-                     zNear, zFar);
-  
+                     zNear,  zFar);
 }
+
+
 
 double Camera::getProjectedSphereArea(const Sphere& sphere) const {
   // this implementation is not right exact, but it's faster.

--- a/iOS/G3MiOSSDK/Commons/Rendererers/BusyMeshRenderer.cpp
+++ b/iOS/G3MiOSSDK/Commons/Rendererers/BusyMeshRenderer.cpp
@@ -155,7 +155,7 @@ void BusyMeshRenderer::render(const G3MRenderContext* rc,
   GL* gl = rc->getGL();
   createGLState();
   
-  gl->clearScreen(*_backgroundColor);
+  //gl->clearScreen(*_backgroundColor);
   
   Mesh* mesh = getMesh(rc);
   if (mesh != NULL) {


### PR DESCRIPTION
It includes:
-A fix which avoids zero multiplication and thus zeroed FrustumData in camera resizeViewport() method, when using WebGL and the new calculateFrustumData() method.
-A fix which allows a loading mesh for each eye in stereo mode.
